### PR TITLE
feat: 상품기본정보 - 필터태그

### DIFF
--- a/src/commons/constants/filterTagList.js
+++ b/src/commons/constants/filterTagList.js
@@ -1,0 +1,3 @@
+const FILTER_TAG_LIST = ["베스트", "베나라", "베베"];
+
+export default FILTER_TAG_LIST;

--- a/src/components/Info/elements/FilterSearchResult.jsx
+++ b/src/components/Info/elements/FilterSearchResult.jsx
@@ -1,23 +1,31 @@
+/* eslint-disable consistent-return */
 /* eslint-disable no-unused-vars */
 /* eslint-disable react/no-array-index-key */
 import React from "react";
 import FILTER_TAG_LIST from "commons/constants/filterTagList";
 import * as S from "../styled";
 
-function FilterSearchResult({ selectedTags, setSelectedTags }) {
+function FilterSearchResult({
+  savedTagList,
+  selectedTags,
+  setSelectedTags,
+  setIsFocusOn,
+}) {
   const handleAddFilterTag = (event, string) => {
     event.preventDefault();
 
-    if (selectedTags.includes(string)) return;
+    if (selectedTags.includes(string))
+      return alert("이미 태그가 추가되어 있습니다");
 
     setSelectedTags([...selectedTags, string]);
+    setIsFocusOn((prev) => !prev);
   };
 
   return (
     <S.SearchBox>
       <S.TagListBox>
-        {FILTER_TAG_LIST.length > 0 ? (
-          FILTER_TAG_LIST.map((string, index) => (
+        {savedTagList.length > 0 ? (
+          savedTagList.map((string, index) => (
             <S.FilterTag
               key={index}
               onClick={(event) => handleAddFilterTag(event, string)}

--- a/src/components/Info/elements/FilterSearchResult.jsx
+++ b/src/components/Info/elements/FilterSearchResult.jsx
@@ -1,0 +1,34 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable react/no-array-index-key */
+import React from "react";
+import FILTER_TAG_LIST from "commons/constants/filterTagList";
+import * as S from "../styled";
+
+function FilterSearchResult({ selectedTags, setSelectedTags }) {
+  const handleAddFilterTag = (event, string) => {
+    event.preventDefault();
+
+    setSelectedTags([...selectedTags, string]);
+  };
+
+  return (
+    <S.SearchBox>
+      <S.TagListBox>
+        {FILTER_TAG_LIST.length > 0 ? (
+          FILTER_TAG_LIST.map((string, index) => (
+            <S.FilterTag
+              key={index}
+              onClick={(event) => handleAddFilterTag(event, string)}
+            >
+              {string}
+            </S.FilterTag>
+          ))
+        ) : (
+          <span>검색 결과가 존재하지 않습니다</span>
+        )}
+      </S.TagListBox>
+    </S.SearchBox>
+  );
+}
+
+export default FilterSearchResult;

--- a/src/components/Info/elements/FilterSearchResult.jsx
+++ b/src/components/Info/elements/FilterSearchResult.jsx
@@ -8,6 +8,8 @@ function FilterSearchResult({ selectedTags, setSelectedTags }) {
   const handleAddFilterTag = (event, string) => {
     event.preventDefault();
 
+    if (selectedTags.includes(string)) return;
+
     setSelectedTags([...selectedTags, string]);
   };
 

--- a/src/components/Info/index.jsx
+++ b/src/components/Info/index.jsx
@@ -1,6 +1,9 @@
+/* eslint-disable react/no-array-index-key */
+/* eslint-disable no-unused-vars */
 /* eslint-disable no-unused-expressions */
 import React, { useEffect, useState } from "react";
 import ImageAttachment from "../../commons/components/ImageAttachment";
+import FilterSearchResult from "./elements/FilterSearchResult";
 import * as S from "./styled";
 
 const productCode = Math.floor(Math.random() * 10000000000)
@@ -9,6 +12,8 @@ const productCode = Math.floor(Math.random() * 10000000000)
 
 function Info() {
   const [inputFields, setInputFields] = useState({ productCode });
+  const [isFocusOn, setIsFocusOn] = useState(false);
+  const [selectedTags, setSelectedTags] = useState([]);
 
   const handleChangeInput = (event, key, imgFiles = []) => {
     const values = { ...inputFields };
@@ -19,16 +24,60 @@ function Info() {
     setInputFields(values);
   };
 
+  const handleFocus = () => {
+    setIsFocusOn((prev) => !prev);
+  };
+
+  const handleDeleteFilterTag = (event, index) => {
+    console.log(event, index);
+  };
+
   // state 확인용 => App.js에서 최종 머지후 제거
   useEffect(() => {
-    console.log(inputFields);
-  }, [inputFields]);
+    console.log(`selectedTags : ${selectedTags}`);
+  }, [selectedTags]);
 
   return (
     <S.Table>
       <tbody>
         <tr>
           <S.Title colSpan="2">상품 기본 정보</S.Title>
+        </tr>
+        <tr>
+          <S.Content>필터태그</S.Content>
+          <S.SettingBox colSpan="3">
+            <input
+              type="text"
+              name="filterSearch"
+              id="filterSearch"
+              placeholder="상품명을 입력해 주세요."
+              onFocus={handleFocus}
+              // onBlur={handleFocus}
+              onChange={handleChangeInput}
+            />
+            {isFocusOn && (
+              <FilterSearchResult
+                selectedTags={selectedTags}
+                setSelectedTags={setSelectedTags}
+              />
+            )}
+            {selectedTags.length > 0 && (
+              <S.SelectedTag>
+                <div>지정된 필터 태그</div>
+                <S.TagListBox>
+                  {selectedTags.map((tag, index) => (
+                    <S.FilterTag
+                      key={index}
+                      onClick={(event) => handleDeleteFilterTag(event, index)}
+                    >
+                      {tag}
+                      {" X"}
+                    </S.FilterTag>
+                  ))}
+                </S.TagListBox>
+              </S.SelectedTag>
+            )}
+          </S.SettingBox>
         </tr>
         <tr>
           <S.Content>상품명</S.Content>

--- a/src/components/Info/index.jsx
+++ b/src/components/Info/index.jsx
@@ -1,7 +1,9 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
 /* eslint-disable react/no-array-index-key */
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-unused-expressions */
 import React, { useEffect, useState } from "react";
+import FILTER_TAG_LIST from "commons/constants/filterTagList";
 import ImageAttachment from "../../commons/components/ImageAttachment";
 import FilterSearchResult from "./elements/FilterSearchResult";
 import * as S from "./styled";
@@ -13,6 +15,7 @@ const productCode = Math.floor(Math.random() * 10000000000)
 function Info() {
   const [inputFields, setInputFields] = useState({ productCode });
   const [isFocusOn, setIsFocusOn] = useState(false);
+  const [savedTagList, setSavedTagList] = useState([...FILTER_TAG_LIST]);
   const [selectedTags, setSelectedTags] = useState([]);
 
   const handleChangeInput = (event, key, imgFiles = []) => {
@@ -34,10 +37,24 @@ function Info() {
     setSelectedTags(result);
   };
 
+  const handleSearchChange = (event) => {
+    const searchWord = event.target.value;
+
+    if (searchWord === "") return;
+
+    // indexOf가 -1이면 일치하는 단어가 없다
+    const result = FILTER_TAG_LIST.filter(
+      (string) => string.indexOf(searchWord) !== -1
+    );
+
+    setSavedTagList(result);
+  };
+
   // state 확인용 => App.js에서 최종 머지후 제거
   useEffect(() => {
+    console.log(`savedTagList : ${savedTagList}`);
     console.log(`selectedTags : ${selectedTags}`);
-  }, [selectedTags]);
+  }, [savedTagList, selectedTags]);
 
   return (
     <S.Table>
@@ -54,12 +71,14 @@ function Info() {
               id="filterSearch"
               placeholder="상품명을 입력해 주세요."
               onFocus={handleFocus}
-              onChange={handleChangeInput}
+              onChange={handleSearchChange}
             />
             {isFocusOn && (
               <FilterSearchResult
+                savedTagList={savedTagList}
                 selectedTags={selectedTags}
                 setSelectedTags={setSelectedTags}
+                setIsFocusOn={setIsFocusOn}
               />
             )}
             {selectedTags.length > 0 && (

--- a/src/components/Info/index.jsx
+++ b/src/components/Info/index.jsx
@@ -29,7 +29,9 @@ function Info() {
   };
 
   const handleDeleteFilterTag = (event, index) => {
-    console.log(event, index);
+    const result = selectedTags.filter((_, i) => i !== index);
+
+    setSelectedTags(result);
   };
 
   // state 확인용 => App.js에서 최종 머지후 제거
@@ -52,7 +54,6 @@ function Info() {
               id="filterSearch"
               placeholder="상품명을 입력해 주세요."
               onFocus={handleFocus}
-              // onBlur={handleFocus}
               onChange={handleChangeInput}
             />
             {isFocusOn && (

--- a/src/components/Info/styled.js
+++ b/src/components/Info/styled.js
@@ -42,3 +42,25 @@ export const SplitRightBox = styled.td`
   width: 160px;
   border-bottom: 1px solid #cccccc;
 `;
+
+export const SearchBox = styled.div`
+  border-radius: 10px;
+  border: 2px solid #eee;
+  margin: 20px 0;
+`;
+
+export const FilterTag = styled.span`
+  border-radius: 4px;
+  padding: 5px 7px;
+  background-color: #e8f7d3;
+  margin-right: 10px;
+`;
+
+export const SelectedTag = styled.div`
+  width: 100%;
+  padding: 10px 10px;
+`;
+
+export const TagListBox = styled.div`
+  padding: 30px 20px;
+`;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24728385/151647021-3182f22d-51a7-476d-9af8-03a53f6b0ff7.png)

![image](https://user-images.githubusercontent.com/24728385/151647030-b139e358-f910-43c7-86d6-5897226d4111.png)

![image](https://user-images.githubusercontent.com/24728385/151647038-650c8de0-9524-4622-9cad-928f2468f70d.png)

1. 필터태그
    - [x]  임시 필터 리스트 만들어두기 (’베스트’, ‘베나라’, ‘베베')
    - [x]  검색창 포커스 시 모든 필터태그 밑에 추가
    - [x]  검색어 정렬
        - [x]  검색어 텍스트(’자’기준)으로 높은 순으로 리스팅
        - [x]  일치값순 동일율인 경우 서버에서 내려주는 데이터 순으로 노출
    - [x]  필터태그 tab시 추가 (selectedFilter에서 추가)
        - [x]  이미 지정된 태그를 재선택 하는 경우, 중복으로 추가되지 않고 기존 지정 태그 유지 (includes 사용)
    - [x]  필터태그 X 버튼 누르면 해제 (selectedFilter에서 제거)